### PR TITLE
Add main to github-actions

### DIFF
--- a/templates/.github/workflows/golangci-lint.yml
+++ b/templates/.github/workflows/golangci-lint.yml
@@ -5,6 +5,7 @@ on:
       - v*
     branches:
       - master
+      - main
   pull_request:
 jobs:
   golangci:

--- a/templates/.github/workflows/test.yml
+++ b/templates/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
       - v*
     branches:
       - master
+      - main
   pull_request:
 env:
   GO111MODULE: "on"


### PR DESCRIPTION
Recently github has changed default branch for new repositories to `main`. This PR updates relevant templates to include `main` as a `master` branch.