### PR TITLE
Use gorelease fork as a temporary workaround for missing generic support

### DIFF
--- a/templates/github/workflows/gorelease.yml
+++ b/templates/github/workflows/gorelease.yml
@@ -35,12 +35,12 @@ jobs:
         with:
           path: |
             ~/go/bin/gorelease
-          key: ${{ runner.os }}-gorelease
+          key: ${{ runner.os }}-gorelease-fork
       - name: Gorelease
         id: gorelease
         run: |
-          test -e ~/go/bin/gorelease || go install golang.org/x/exp/cmd/gorelease@latest
-          OUTPUT=$(gorelease || exit 0)
+          test -e ~/go/bin/gorelease || (rm -rf /tmp/gorelease && mkdir -p /tmp/gorelease && cd /tmp/gorelease && go mod init foo && go mod edit -replace golang.org/x/exp=github.com/vearutop/golang-exp@gorelease-generic && go get golang.org/x/exp/cmd/gorelease && go install golang.org/x/exp/cmd/gorelease)
+          OUTPUT=$(gorelease 2>&1 || exit 0)
           echo "${OUTPUT}"
           OUTPUT="${OUTPUT//$'\n'/%0A}"
           echo "::set-output name=report::$OUTPUT"


### PR DESCRIPTION
Until https://github.com/golang/go/issues/52486 is properly fixed, https://github.com/vearutop/golang-exp/tree/gorelease-generic can be used to mitigate the error (by falling back to equality check of type parameters).