### PR TITLE
Fix start-deps

### DIFF
--- a/makefiles/test-integration.mk
+++ b/makefiles/test-integration.mk
@@ -13,10 +13,10 @@ test-integration:
 
 ## Start dependencies for integration tests or local dev via docker-compose up
 start-deps:
-	@test ! -f $(INTEGRATION_DOCKER_COMPOSE) || docker-compose -p "$(shell basename $$PWD)" -f $(INTEGRATION_DOCKER_COMPOSE) up -d
+	test ! -f $(INTEGRATION_DOCKER_COMPOSE) || (command -v docker-compose >/dev/null 2>&1 && docker-compose -p "$(shell basename $$PWD)" -f $(INTEGRATION_DOCKER_COMPOSE) up -d || docker compose -p "$(shell basename $$PWD)" -f $(INTEGRATION_DOCKER_COMPOSE) up -d)
 
 ## Stop dependencies for integration tests or local dev via docker-compose down
 stop-deps:
-	@test ! -f $(INTEGRATION_DOCKER_COMPOSE) || docker-compose -p "$(shell basename $$PWD)" -f $(INTEGRATION_DOCKER_COMPOSE) down
+	@test ! -f $(INTEGRATION_DOCKER_COMPOSE) || (command -v docker-compose >/dev/null 2>&1 && docker-compose -p "$(shell basename $$PWD)" -f $(INTEGRATION_DOCKER_COMPOSE) down || docker compose -p "$(shell basename $$PWD)" -f $(INTEGRATION_DOCKER_COMPOSE) down)
 
 .PHONY: test-integration start-deps stop-deps


### PR DESCRIPTION
## Bug

I encountered the error "docker-compose command not found" when running `test-integration`.

## Solution

Github actions use `docker compose` instead of `docker-compose`.

## Fix

Fix both Makefile target `start-deps` and `stop-deps` to check whether the command `docker-compose` (run locally) exists or `docker-compose` (run github actions) exists, and use it to spin up the containes